### PR TITLE
Add mnemonics to Boards menu: a-z,A-Z,0-9

### DIFF
--- a/app/src/processing/app/Editor.java
+++ b/app/src/processing/app/Editor.java
@@ -741,6 +741,7 @@ public class Editor extends JFrame implements RunnerListener {
 
     if (portMenu == null)
       portMenu = new JMenu(tr("Port"));
+      portMenu.setMnemonic('P');
     populatePortMenu();
     toolsMenu.add(portMenu);
     MenuScroller.setScrollerFor(portMenu);
@@ -1109,6 +1110,7 @@ public class Editor extends JFrame implements RunnerListener {
 
     String lastProtocol = "";
     String lastProtocolLabel = "";
+    int i=0;
     for (BoardPort port : ports) {
       if (!port.getProtocol().equals(lastProtocol) || !port.getProtocolLabel().equals(lastProtocolLabel)) {
         if (!lastProtocol.isEmpty()) {
@@ -1124,12 +1126,13 @@ public class Editor extends JFrame implements RunnerListener {
 
       BoardPortJCheckBoxMenuItem item = new BoardPortJCheckBoxMenuItem(port);
       item.setSelected(address.equals(selectedPort));
+      Base.setMenuItemMnemonicNum10(item, i, false);
+      i++;
       portMenu.add(item);
     }
 
     portMenu.setEnabled(portMenu.getMenuComponentCount() > 0);
   }
-
 
   private JMenu buildHelpMenu() {
     JMenu menu = new JMenu(tr("Help"));


### PR DESCRIPTION
Adds keystrokes to the Tools menu for (B)oards and (P)orts, as well is to those submenus themselves.

This is not only useful for switching more-quickly between projects, but also likely for accessibility, screen-readers, etc.

A couple functions have been added for selecting incremental letters/digits. They can be used for other menus as well.

All Submissions:
[*] Have you followed the guidelines in our Contributing document?
[*] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/arduino/Arduino/pulls?q=) for the same update/change?
New Feature Submissions:
[*] Does your submission pass tests?
[*] Have you lint your code locally prior to submission?
Changes to Core Features:
[*] Have you added an explanation of what your changes do and why you'd like us to include them?
[n/a?] Have you written new tests for your core changes, as applicable?
[*] Have you successfully ran tests with your changes