### PR TITLE
Add serial monitor send/receive encoding options

### DIFF
--- a/app/src/processing/app/AbstractTextMonitor.java
+++ b/app/src/processing/app/AbstractTextMonitor.java
@@ -3,21 +3,17 @@ package processing.app;
 import static processing.app.I18n.tr;
 
 import java.awt.BorderLayout;
-import java.awt.Color;
 import java.awt.Container;
 import java.awt.Dimension;
 import java.awt.Font;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
-import java.awt.event.KeyListener;
-import java.awt.event.MouseWheelListener;
 import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.StringTokenizer;
 
-import javax.swing.Action;
 import javax.swing.Box;
 import javax.swing.BoxLayout;
 import javax.swing.JButton;
@@ -25,13 +21,11 @@ import javax.swing.JCheckBox;
 import javax.swing.JComboBox;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
-import javax.swing.JPopupMenu;
 import javax.swing.JScrollPane;
 import javax.swing.JTextField;
 import javax.swing.SwingUtilities;
 import javax.swing.border.EmptyBorder;
 import javax.swing.text.DefaultCaret;
-import javax.swing.text.DefaultEditorKit;
 
 import cc.arduino.packages.BoardPort;
 
@@ -46,24 +40,17 @@ public abstract class AbstractTextMonitor extends AbstractMonitor {
   protected JButton clearButton;
   protected JCheckBox autoscrollBox;
   protected JCheckBox addTimeStampBox;
+  protected JComboBox<String> sendEncoding;
+  protected JComboBox<String> receiveEncoding;
   protected JComboBox<String> lineEndings;
   protected JComboBox<String> serialRates;
 
-  public AbstractTextMonitor(BoardPort boardPort) {
+  public AbstractTextMonitor(Base base, BoardPort boardPort) {
     super(boardPort);
-  }
 
-  @Override
-  public synchronized void addMouseWheelListener(MouseWheelListener l) {
-    super.addMouseWheelListener(l);
-    textArea.addMouseWheelListener(l);
-  }
-
-  @Override
-  public synchronized void addKeyListener(KeyListener l) {
-    super.addKeyListener(l);
-    textArea.addKeyListener(l);
-    textField.addKeyListener(l);
+    // Add font size adjustment listeners. This has to be done here due to
+    // super(boardPort) invoking onCreateWindow(...) before we can store base.
+    base.addEditorFontResizeListeners(textArea);
   }
 
   @Override
@@ -97,23 +84,6 @@ public abstract class AbstractTextMonitor extends AbstractMonitor {
       }
     });
 
-    // Add cut/copy/paste contextual menu to the text input field.
-    JPopupMenu menu = new JPopupMenu();
-
-    Action cut = new DefaultEditorKit.CutAction();
-    cut.putValue(Action.NAME, tr("Cut"));
-    menu.add(cut);
-
-    Action copy = new DefaultEditorKit.CopyAction();
-    copy.putValue(Action.NAME, tr("Copy"));
-    menu.add(copy);
-
-    Action paste = new DefaultEditorKit.PasteAction();
-    paste.putValue(Action.NAME, tr("Paste"));
-    menu.add(paste);
-
-    textField.setComponentPopupMenu(menu);
-
     sendButton = new JButton(tr("Send"));
     clearButton = new JButton(tr("Clear output"));
 
@@ -137,7 +107,45 @@ public abstract class AbstractTextMonitor extends AbstractMonitor {
     minimumSize.setSize(minimumSize.getWidth() / 3, minimumSize.getHeight());
     noLineEndingAlert.setMinimumSize(minimumSize);
 
-    lineEndings = new JComboBox<>(new String[]{tr("No line ending"), tr("Newline"), tr("Carriage return"), tr("Both NL & CR")});
+    String sendAs = tr("Send as") + " ";
+    sendEncoding = new JComboBox<>(new String[] {
+        sendAs + EncodingOption.SYSTEM_DEFAULT,
+        sendAs + EncodingOption.BYTES,
+        sendAs + EncodingOption.UTF_8,
+        sendAs + EncodingOption.UTF_16,
+        sendAs + EncodingOption.UTF_16BE,
+        sendAs + EncodingOption.UTF_16LE,
+        sendAs + EncodingOption.ISO_8859_1,
+        sendAs + EncodingOption.US_ASCII});
+    sendEncoding.addActionListener(new ActionListener() {
+      public void actionPerformed(ActionEvent event) {
+        PreferencesData.set("serial.send_encoding", sendEncoding.getItemAt(
+            sendEncoding.getSelectedIndex()).substring(sendAs.length()));
+      }
+    });
+    String sendEncodingStr = PreferencesData.get("serial.send_encoding");
+    if (sendEncodingStr != null) {
+      sendEncoding.setSelectedItem(sendAs + sendEncodingStr);
+    }
+    sendEncoding.setMaximumSize(sendEncoding.getMinimumSize());
+
+    String receiveAs = tr("Receive as") + " ";
+    receiveEncoding = new JComboBox<>(new String[] {
+        receiveAs + EncodingOption.SYSTEM_DEFAULT,
+        receiveAs + EncodingOption.BYTES,
+        receiveAs + EncodingOption.UTF_8,
+        receiveAs + EncodingOption.UTF_16,
+        receiveAs + EncodingOption.UTF_16BE,
+        receiveAs + EncodingOption.UTF_16LE,
+        receiveAs + EncodingOption.ISO_8859_1,
+        receiveAs + EncodingOption.US_ASCII});
+    String receiveEncodingStr = PreferencesData.get("serial.receive_encoding");
+    if (receiveEncodingStr != null) {
+      receiveEncoding.setSelectedItem(receiveAs + receiveEncodingStr);
+    }
+    receiveEncoding.setMaximumSize(receiveEncoding.getMinimumSize());
+
+    lineEndings = new JComboBox<String>(new String[]{tr("No line ending"), tr("Newline"), tr("Carriage return"), tr("Both NL & CR")});
     lineEndings.addActionListener((ActionEvent event) -> {
       PreferencesData.setInteger("serial.line_ending", lineEndings.getSelectedIndex());
       noLineEndingAlert.setForeground(pane.getBackground());
@@ -147,7 +155,7 @@ public abstract class AbstractTextMonitor extends AbstractMonitor {
 
     lineEndings.setMaximumSize(lineEndings.getMinimumSize());
 
-    serialRates = new JComboBox<>();
+    serialRates = new JComboBox<String>();
     for (String rate : serialRateStrings) {
       serialRates.addItem(rate + " " + tr("baud"));
     }
@@ -158,6 +166,10 @@ public abstract class AbstractTextMonitor extends AbstractMonitor {
     pane.add(addTimeStampBox);
     pane.add(Box.createHorizontalGlue());
     pane.add(noLineEndingAlert);
+    pane.add(Box.createRigidArea(new Dimension(8, 0)));
+    pane.add(sendEncoding);
+    pane.add(Box.createRigidArea(new Dimension(8, 0)));
+    pane.add(receiveEncoding);
     pane.add(Box.createRigidArea(new Dimension(8, 0)));
     pane.add(lineEndings);
     pane.add(Box.createRigidArea(new Dimension(8, 0)));
@@ -172,27 +184,17 @@ public abstract class AbstractTextMonitor extends AbstractMonitor {
 
   @Override
   protected void onEnableWindow(boolean enable) {
-    // never actually disable textArea, so people can
-    // still select & copy text, even when the port
-    // is closed or disconnected
-    textArea.setEnabled(true);
-    if (enable) {
-      // setting these to null for system default
-      // gives a wrong gray background on Windows
-      // so assume black text on white background
-      textArea.setForeground(Color.BLACK);
-      textArea.setBackground(Color.WHITE);
-    } else {
-      // In theory, UIManager.getDefaults() should
-      // give us the system's colors for disabled
-      // windows.  But it doesn't seem to work.  :(
-      textArea.setForeground(new Color(64, 64, 64));
-      textArea.setBackground(new Color(238, 238, 238));
-    }
-    textArea.invalidate();
+    textArea.setEnabled(enable);
+    clearButton.setEnabled(enable);
     scrollPane.setEnabled(enable);
     textField.setEnabled(enable);
     sendButton.setEnabled(enable);
+    autoscrollBox.setEnabled(enable);
+    addTimeStampBox.setEnabled(enable);
+    sendEncoding.setEnabled(enable);
+    receiveEncoding.setEnabled(enable);
+    lineEndings.setEnabled(enable);
+    serialRates.setEnabled(enable);
   }
 
   public void onSendCommand(ActionListener listener) {
@@ -206,6 +208,10 @@ public abstract class AbstractTextMonitor extends AbstractMonitor {
 
   public void onSerialRateChange(ActionListener listener) {
     serialRates.addActionListener(listener);
+  }
+
+  public void onReceiveEncodingChange(ActionListener listener) {
+    receiveEncoding.addActionListener(listener);
   }
 
   @Override

--- a/app/src/processing/app/EncodingOption.java
+++ b/app/src/processing/app/EncodingOption.java
@@ -1,0 +1,77 @@
+package processing.app;
+
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * Represents the encoding option for decoding or encoding bytes that are
+ * read from or written to a stream.
+ */
+public enum EncodingOption {
+
+  /**
+   * The system default character set as returned by
+   * {@link Charset#defaultCharset()}.
+   */
+  SYSTEM_DEFAULT(Charset.defaultCharset()),
+  
+  /**
+   * Comma separated unsigned byte representation.
+   */
+  BYTES(null),
+  
+  UTF_8(StandardCharsets.UTF_8),
+  UTF_16(StandardCharsets.UTF_16),
+  UTF_16BE(StandardCharsets.UTF_16BE),
+  UTF_16LE(StandardCharsets.UTF_16LE),
+  ISO_8859_1(StandardCharsets.ISO_8859_1),
+  US_ASCII(StandardCharsets.US_ASCII);
+
+  private final Charset charset;
+
+  private EncodingOption(Charset charset) {
+    this.charset = charset;
+  }
+
+  public Charset getCharset() {
+    return this.charset;
+  }
+
+  @Override
+  public String toString() {
+    switch (this) {
+      case SYSTEM_DEFAULT:
+      case BYTES:
+        return this.name().replace('_', ' ').toLowerCase();
+      default:
+        return this.charset.name();
+    }
+  }
+
+  /**
+   * Gets the {@link EncodingOption} with the given name.
+   * The name match is case-insensitive and
+   * whitespaces/dashes are interpreted as '_'.
+   * @param name - The name of the {@link EncodingOption}.
+   * @return The matching {@link EncodingOption}
+   * or null when no such option exists.
+   */
+  public static EncodingOption forName(String name) {
+    if (name == null) {
+      return null;
+    }
+    try {
+      return EncodingOption.valueOf(
+          name.replace(' ', '_').replace('-', '_').toUpperCase());
+    } catch (IllegalArgumentException e) {
+      return null;
+    }
+//    name = name.replace(' ', '_').replace('-', '_');
+//    for (EncodingOption option : EncodingOption.values()) {
+//      if (option.name().equalsIgnoreCase(name)) {
+//        return option;
+//      }
+//    }
+//    return null;
+  }
+}


### PR DESCRIPTION
* Add "send as " dropdown menu.
* Add "receive as " dropdown menu.

Sending and receiving can be done in any encoding specified in StandardCharsets with the additional option to send comma-separated bytes and receive newline-separated bytes directly.

This fixes https://github.com/arduino/arduino-ide/issues/1728 and offers an easy implementation for issue https://github.com/arduino/arduino-ide/issues/1727.